### PR TITLE
update shibboleth package from 7 to 8

### DIFF
--- a/40univention-owncloud-saml.inst
+++ b/40univention-owncloud-saml.inst
@@ -64,7 +64,7 @@ udm settings/portal_entry create "$@" --ignore_exists --position "cn=portal,cn=u
 	--set portal="cn=domain,cn=portal,cn=univention,$ldap_base"
 
 univention-app shell owncloud apt-get update -qq
-univention-app shell owncloud apt-get install --assume-yes libshibsp7 libapache2-mod-shib2 libshibsp-doc sudo
+univention-app shell owncloud apt-get install --assume-yes libshibsp8 libapache2-mod-shib2 libshibsp-doc sudo
 docker cp /usr/share/univention-owncloud-saml/shibd.conf "$(ucr get appcenter/apps/owncloud/container)":/etc/apache2/conf-available/
 docker cp /usr/share/univention-owncloud-saml/enable_saml.sh "$(ucr get appcenter/apps/owncloud/container)":/root/
 docker cp /usr/share/univention-owncloud-saml/subpath.conf "$(ucr get appcenter/apps/owncloud/container)":/root/owncloud/


### PR DESCRIPTION
since we upgraded our docker image to ubuntu 19.04 the shibboleth package has to be libshibsp8 now.