### PR TITLE
Shibd cert key perms

### DIFF
--- a/40univention-owncloud-saml.inst
+++ b/40univention-owncloud-saml.inst
@@ -72,7 +72,7 @@ docker cp /usr/share/univention-owncloud-saml/shibboleth2.xml "$(ucr get appcent
 docker cp /usr/share/univention-management-console/saml/idp/*.xml "$(ucr get appcenter/apps/owncloud/container)":/etc/shibboleth/idp.xml
 ssl_path=$(ucr get appcenter/apps/owncloud/hostdn | python -c 'import ldap, sys; print ldap.dn.str2dn(sys.stdin.read())[0][0][1]')
 docker cp "/etc/univention/ssl/$ssl_path/cert.pem" "$(ucr get appcenter/apps/owncloud/container)":/etc/shibboleth/sp-cert.pem
-docker cp "/etc/univention/ssl/$ssl_path/private.key" "$(ucr get appcenter/apps/owncloud/container)":/etc/shibboleth/sp-key.pem  # FIXME: chmod!
+docker cp "/etc/univention/ssl/$ssl_path/private.key" "$(ucr get appcenter/apps/owncloud/container)":/etc/shibboleth/sp-key.pem
 
 univention-app shell owncloud /root/enable_saml.sh
 

--- a/enable_saml.sh
+++ b/enable_saml.sh
@@ -31,6 +31,9 @@ set -ex
 
 . /usr/bin/entrypoint
 
+chmod 600 /etc/shibboleth/sp-key.pem
+chown _shibd. /etc/shibboleth/sp-*.pem
+
 cd /var/www/owncloud
 sudo -u www-data php occ market:upgrade
 sudo -u www-data php occ market:install enterprise_key


### PR DESCRIPTION
Not sure how you would fix this, but I would really like to help get this working properly again. So please let me know if you think this could be done better.

Assigned correct permissions for key file and adjusted ownership to the shibd daemon user for key as well as cert file in the script `enable_saml.sh`.